### PR TITLE
Issue #9: take over as module maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Markdown filter
+Markdown Filter
 =============================
 
 Provides Markdown filter integration for Backdrop input formats. The
@@ -52,12 +52,13 @@ complete text.
 Maintainers
 -----------
 
-- Chris Herberte (https://github.com/chrisherberte)
-- Fredrik Jonsson (https://github.com/frjo)
+- [Robert J. Lang (bugfolder)](https://github.com/bugfolder)
 
 Credits
 -------
-- Markdown created by John Gruber: <http://daringfireball.net>
-- PHP executions by Michel Fortin: <http://www.michelf.com/>
-- Drupal Markdown filter originally by justin2pin: <https://www.drupal.org/project/markdown>
-- Ported to Backdrop by Chris Herberte (https://github.com/chrisherberte)
+- Markdown created by [John Gruber](http://daringfireball.net)
+- PHP executions by [Michel Fortin](http://www.michelf.com/)
+- Drupal Markdown filter originally by [justin2pin](https://www.drupal.org/project/markdown)
+- Ported to Backdrop by [Chris Herberte](https://github.com/chrisherberte)
+- Past Backdrop maintainers: [Chris Herberte](https://github.com/chrisherberte) and [Fredrik Jonsson](https://github.com/frjo)
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Maintainers
 -----------
 
 - [Robert J. Lang (bugfolder)](https://github.com/bugfolder)
+- [Chris Herberte](https://github.com/chrisherberte)
+- [Fredrik Jonsson](https://github.com/frjo)
 
 Credits
 -------
@@ -60,5 +62,4 @@ Credits
 - PHP executions by [Michel Fortin](http://www.michelf.com/)
 - Drupal Markdown filter originally by [justin2pin](https://www.drupal.org/project/markdown)
 - Ported to Backdrop by [Chris Herberte](https://github.com/chrisherberte)
-- Past Backdrop maintainers: [Chris Herberte](https://github.com/chrisherberte) and [Fredrik Jonsson](https://github.com/frjo)
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/markdown/issues/9.

Taking over as module maintainer.